### PR TITLE
fix: use pd.date_range instead of DatetimeIndex

### DIFF
--- a/Time_Series_Forecasting/Energy_Consumption_Exercise.ipynb
+++ b/Time_Series_Forecasting/Energy_Consumption_Exercise.ipynb
@@ -264,7 +264,7 @@
     "data = mean_power_df[start_idx:end_idx]\n",
     "\n",
     "# create time series for the year\n",
-    "index = pd.DatetimeIndex(start=t_start, end=t_end, freq='D')\n",
+    "index = pd.date_range(start=t_start, end=t_end, freq='D')\n",
     "time_series.append(pd.Series(data=data, index=index))\n",
     "```"
    ]


### PR DESCRIPTION
The make_time _series function uses pandas DatetimeIndex  to construct the index for each year's data. However, from Pandas version 1.0 onwards Pandas uses date_range to create a fixed frequency DatetimeIndex.  Solves #3 .